### PR TITLE
Defense Evasion: Remote Access Tool Audit

### DIFF
--- a/MITRE/Defense Evasion/Deobfuscate_Decode Files or Information/RAT-audit.yaml
+++ b/MITRE/Defense Evasion/Deobfuscate_Decode Files or Information/RAT-audit.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-defense-evasion-RAT-decode
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  process:
+    matchPaths:
+    - path: /usr/bin/certutil
+  severity: 5
+  action:
+    Audit


### PR DESCRIPTION
This deobfuscates and decodes a new file that is created. Certuil is used to decode a remote access tool portable executable file that has been hidden inside a certificate file.